### PR TITLE
Resolving Non-Running Problem

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,6 +2,10 @@
 
 buildscript {
     ext {
+        //in order to make notification libary stop complaining
+        googlePlayServicesVersion = "16.1.0" // default: "+"
+        firebaseVersion = "15.0.2" // default: "+"
+        
         buildToolsVersion = "27.0.3"
         minSdkVersion = 16
         compileSdkVersion = 27


### PR DESCRIPTION
Because of the breaking changes in some of the android libaries, that
the notification libary depended on, the app would not longer run. This
change was so that the app can now actually run.